### PR TITLE
Update TranslatableTabToRowTrait.php

### DIFF
--- a/src/TranslatableTabToRowTrait.php
+++ b/src/TranslatableTabToRowTrait.php
@@ -125,7 +125,7 @@ trait TranslatableTabToRowTrait
                 if (array_search($childField->attribute, array_column($this->childFieldsArr, 'attribute')) === false) {
                     // @todo: we should not randomly apply rules to child-fields.
                     $childField = $this->applyRulesForChildFields($childField);
-                    if (isset($field->panel)) $childField->panel = $field->panel;
+                    if (! $field instanceof NovaTabTranslatable && isset($field->panel)) $childField->panel = $field->panel;
                     $this->childFieldsArr[$key][] = $childField;
                 }
             }


### PR DESCRIPTION
We use this plugin with another great plugin https://github.com/eminiarts/nova-tabs.

![Screenshot_20210916_223557](https://user-images.githubusercontent.com/17027876/133682294-70987cba-e4cc-4a0f-8a5e-cc1c72c3e4af.png)

After upgrade to 1.13 it stopped work.

![Screenshot_20210916_223858](https://user-images.githubusercontent.com/17027876/133682574-f9082145-3309-4b1c-abda-2433a8879b64.png)

Console error:

> TypeError: Cannot read property 'tabClass' of undefined
>     at a.getTabClass (tabs:1)
>     at tabs:1

This PR fixes it but I am sure there is a better option. 