### PR TITLE
Update NovaTabTranslatable.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Making Laravel Nova Tab Translatable
+# Making Laravel Nova Tab Translatable Nova 5 ready
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/kongulov/nova-tab-translatable?style=flat-square)](https://packagist.org/packages/kongulov/nova-tab-translatable)
 ![Licence](https://img.shields.io/github/license/kongulov/nova-tab-translatable?style=flat-square)
 [![Total Downloads](https://poser.pugx.org/kongulov/nova-tab-translatable/downloads?format=flat-square)](https://packagist.org/packages/kongulov/nova-tab-translatable)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total Downloads](https://poser.pugx.org/kongulov/nova-tab-translatable/downloads?format=flat-square)](https://packagist.org/packages/kongulov/nova-tab-translatable)
 
 
-This package contains a `NovaTabTranslatable` class you can use to make any Nova field type translatable with tabs.
+This package contains a `NovaTabTranslatable` class you can use to make any Nova field type translatable with tabs. Use the master branch for Nova 5 and the 1.x branch for Nova 4.
 
 Imagine you have this `fields` method in a Post Nova resource:
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-translatable": "^5.0|^6.0",
-        "laravel/nova": "^4.0"
+        "laravel/nova": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-translatable": "^5.0|^6.0",
-        "laravel/nova": "^4.0|^5.0"
+        "laravel/nova": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/nova.mix.js
+++ b/nova.mix.js
@@ -14,7 +14,6 @@ class NovaExtension {
   webpackPlugins() {
     return new webpack.ProvidePlugin({
       _: 'lodash',
-      Errors: 'form-backend-validation',
     })
   }
 

--- a/src/NovaTabTranslatable.php
+++ b/src/NovaTabTranslatable.php
@@ -86,7 +86,7 @@ class NovaTabTranslatable extends Field
         ]);
     }
 
-    protected function createTranslatableFields()
+    protected function createTranslatableFields(): void
     {
         collect($this->locales)
             ->crossJoin($this->originalFields)
@@ -244,21 +244,21 @@ class NovaTabTranslatable extends Field
         return $translatedField;
     }
 
-    public function resolve($resource, $attribute = null)
+    public function resolve($resource, $attribute = null): void
     {
         foreach ($this->data as $field) {
             $field->resolve($resource, $attribute);
         }
     }
 
-    public function fillInto($request, $model, $attribute, $requestAttribute = null)
+    public function fillInto($request, $model, $attribute, $requestAttribute = null): void
     {
         foreach ($this->data as $field) {
             $field->fill($request, $model);
         }
     }
 
-    public function getCreationRules(NovaRequest $request)
+    public function getCreationRules(NovaRequest $request): array
     {
         $fieldsRules = $this->getSituationalRulesSet($request, 'creationRules');
 
@@ -268,7 +268,7 @@ class NovaTabTranslatable extends Field
         );
     }
 
-    protected function getSituationalRulesSet(NovaRequest $request, string $propertyName = 'rules')
+    protected function getSituationalRulesSet(NovaRequest $request, string $propertyName = 'rules'): array
     {
         $fieldsRules = [$this->attribute => []];
 
@@ -281,7 +281,7 @@ class NovaTabTranslatable extends Field
         return $fieldsRules;
     }
 
-    public function getUpdateRules(NovaRequest $request)
+    public function getUpdateRules(NovaRequest $request): array
     {
         $fieldsRules = $this->getSituationalRulesSet($request, 'updateRules');
 
@@ -291,7 +291,7 @@ class NovaTabTranslatable extends Field
         );
     }
 
-    public function getRules(NovaRequest $request)
+    public function getRules(NovaRequest $request): array
     {
         return $this->getSituationalRulesSet($request);
     }

--- a/src/NovaTabTranslatable.php
+++ b/src/NovaTabTranslatable.php
@@ -40,19 +40,20 @@ class NovaTabTranslatable extends Field
 
     public $panel;
 
-    public function __construct(array $fields = [])
+    public function __construct(array $fields = [], array $locales = [])
     {
         parent::__construct($this->name);
         $config = config('tab-translatable');
-        if ($config['source'] == 'database')
+        if ($config['source'] == 'database') {
             $this->locales = $config['database']['model']::query()
                 ->when(isset($config['database']['sort_by']), function ($query) use ($config) {
                     $query->orderBy($config['database']['sort_by'], $config['database']['sort_direction']);
                 })
                 ->pluck($config['database']['code_field'])
                 ->toArray();
-        else
-            $this->locales = $config['locales'];
+        } else {
+            $this->locales = count($locales) > 0 ? $locales : $config['locales'];
+        }
 
         $this->displayLocalizedNameUsingCallback = self::$displayLocalizedNameByDefaultUsingCallback ?? function (Field $field, string $locale) {
             return ucfirst($field->name) . " [{$locale}]";

--- a/src/NovaTabTranslatable.php
+++ b/src/NovaTabTranslatable.php
@@ -14,10 +14,13 @@ use Laravel\Nova\Fields\File;
 use Laravel\Nova\Fields\Image;
 use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Fields\SupportsDependentFields;
 use Throwable;
 
 class NovaTabTranslatable extends Field
 {
+    use SupportsDependentFields;
+    
     /**
      * The field's component.
      *


### PR DESCRIPTION
Add $locales variable to construct method to allow custom locales per field use in nova. In my use case this make sense, to pass different locales languages array on a per user basis to the field component. Maybe it is also useful for others, just a small code change.